### PR TITLE
Fix tests for some environments

### DIFF
--- a/test/Injector.spec.ts
+++ b/test/Injector.spec.ts
@@ -1,5 +1,6 @@
 import 'mocha';
 import 'sinon';
+import 'tabris';
 import { expect, restoreSandbox } from './test';
 import { InjectionHandlerFunction, Injector } from '../src';
 /* tslint:disable:no-unused-expression max-classes-per-file */


### PR DESCRIPTION
It seems on some environments, tests are run in another order, for which
the 'tabris' module gets loaded too late. Include a 'tabris' import in
Injector.spec.ts since in some cases it may be the first test.

Change-Id: I299a7a91912e4fbf521312bccf58b48fa7ed5042