### PR TITLE
Set compiler target to ES5

### DIFF
--- a/src/api/Listeners.ts
+++ b/src/api/Listeners.ts
@@ -79,7 +79,7 @@ export class Listeners<T extends object = {}> {
    */
   public async resolve(): Promise<T>;
   public async resolve(value?: object): Promise<object> {
-    let hasValue = arguments.length === 1;
+    let hasValue = typeof value !== 'undefined';
     return new Promise(resolve => {
       this.once(ev => {
         if (hasValue) {

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es6",
+    "target": "es5",
     "rootDirs": ["src", "test"],
     "lib": ["es6", "es2015.promise" ],
     "experimentalDecorators": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
+    "target": "es5",
     "lib": ["es6", "es2015.promise" ],
     "outDir": "./dist/",
     "rootDir": "./src/",


### PR DESCRIPTION
Improve compatibility with older iOS versions.

"arguments" cannot be used in methods and lambdas when target is set to ES3 or ES5, so adjust Listeners#resolve() accordingly.

Change-Id: I35c9fd0639711972e2d25ec81f4da232d8e62afd