### PR TITLE
Update examples

### DIFF
--- a/examples/bind-and-convert/README.md
+++ b/examples/bind-and-convert/README.md
@@ -1,0 +1,9 @@
+# Example "bind-and-convert"
+
+Demonstrates the use of converter functions and template syntax in one-way bindings. This app creates an instance of the included `ExampleComponent` class and a checkbox that allows to change the property values of that instance.
+
+The `ExampleComponent` the property `myTime` is of the type `Date` and is converted to a string to bind to the `text` properties of multiple `TextView` children. Three variations are included, one directly using the `to` helper function, one using a custom converter function (`toTimeString`), and one using the raw data binding configuration object.
+
+The other property `myText` is a `string` that is embedded in to another string as part of the binding. In the first variant this is done via the `template` attribute prefix, but converter functions can also achieve the same effect, as the last two variants demonstrate.
+
+One-way bindings require the `@component` decorator on the custom component class and the `@property` decorator on the component properties.

--- a/examples/bind-and-convert/package.json
+++ b/examples/bind-and-convert/package.json
@@ -1,14 +1,15 @@
 {
-  "name": "bind-one-way",
-  "version": "3.0.0-rc1",
+  "name": "bind-and-convert",
+  "version": "3.1.0",
   "dependencies": {
     "reflect-metadata": "^0.1.13",
-    "tabris": "3.0.0-rc1",
-    "tabris-decorators": "3.0.0-rc1",
+    "tabris": "^3.0.0",
+    "tabris-decorators": "^3.0.0",
     "typescript": "3.3.x"
   },
   "main": "dist/app.js",
   "scripts": {
+    "start": "tabris serve -w -a",
     "build": "tsc -p .",
     "watch": "tsc -p . -w --preserveWatchOutput --inlineSourceMap"
   }

--- a/examples/bind-and-convert/src/ExampleComponent.tsx
+++ b/examples/bind-and-convert/src/ExampleComponent.tsx
@@ -31,6 +31,7 @@ export class ExampleComponent extends Composite {
         <TextView>Exactly the same as:</TextView>
         <TextView bind-text={to('myText', myText => `Hello ${myText}!`)}/>
         <TextView bind-text={{path: 'myText', converter: myText => 'Hello ' + myText + '!'}}/>
+
       </Stack>
     );
     this._find(TextView).set({font: {size: 18}});

--- a/examples/bind-one-way/README.md
+++ b/examples/bind-one-way/README.md
@@ -1,0 +1,9 @@
+# Example "bind-one-way"
+
+Demonstrates the use of the `bind` JSX attribute prefix to create one-way bindings from a custom component instance to its children. This app creates an instance of the included `ExampleComponent` class and a checkbox that allows to change the property values of that instance.
+
+The `ExampleComponent` the property `myText` is bound the `text` properties of multiple `TextView` children. The first two variants have the same effect, just using different syntax. The third variant demonstrates how to define a fallback value. It will be displayed when the property `myText` is set to `undefined`, which is the case when the checkbox is not checked.
+
+The other property `myObject` is of the type `Model`, which is defined in the same file as `ExampleComponent`. In the component the `Model` field `someString` is bound to the `TextView` property `text` and `someNumber` to the `ProgressBar` property `selection` properties, once with and without a fallback value.
+
+One-way bindings require the `@component` decorator on the custom component class and the `@property` decorator on the component properties.

--- a/examples/bind-one-way/package.json
+++ b/examples/bind-one-way/package.json
@@ -1,14 +1,15 @@
 {
   "name": "bind-one-way",
-  "version": "3.0.0-rc1",
+  "version": "3.1.0",
   "dependencies": {
     "reflect-metadata": "^0.1.13",
-    "tabris": "3.0.0-rc1",
-    "tabris-decorators": "3.0.0-rc1",
+    "tabris": "^3.0.0",
+    "tabris-decorators": "^3.0.0",
     "typescript": "3.3.x"
   },
   "main": "dist/app.js",
   "scripts": {
+    "start": "tabris serve -w -a",
     "build": "tsc -p .",
     "watch": "tsc -p . -w --preserveWatchOutput --inlineSourceMap"
   }

--- a/examples/bind-two-way-change-events/README.md
+++ b/examples/bind-two-way-change-events/README.md
@@ -1,0 +1,9 @@
+# Example "bind-two-way-change-events"
+
+Demonstrates that two-way bindings created via the `@bind` decorator trigger property change events on the component instance. This app creates an instance of the included `ExampleComponent` class (grey background), which has properties that can be changed by interacting with the component. The current value of the properties are displayed below the component.
+
+The `ExampleComponent` the property `myNumber` is bound the `selection` property of a `Slider` with the id `source1`. Moving the slider changes the value of `myNumber` and notifies change listeners registered via `onMyNumberChanged`. In `app.tsx` this is used to update the value of the progress bar below the component.
+
+The other property `myText` is bound the `text` property of a `TextInput` with the id `source2`. Editing the text changes the value of `myText` and notifies change listeners registered via `onMyTextChanged`. In `app.tsx` this is used to update the value of the text view below the component.
+
+Two-way bindings also require the `@component` decorator on the custom component class.

--- a/examples/bind-two-way-change-events/package.json
+++ b/examples/bind-two-way-change-events/package.json
@@ -1,14 +1,15 @@
 {
   "name": "bind-two-way-change-events",
-  "version": "3.0.0-rc1",
+  "version": "3.1.0",
   "dependencies": {
     "reflect-metadata": "^0.1.13",
-    "tabris": "3.0.0-rc1",
-    "tabris-decorators": "3.0.0-rc1",
+    "tabris": "^3.0.0",
+    "tabris-decorators": "^3.0.0",
     "typescript": "3.3.x"
   },
   "main": "dist/app.js",
   "scripts": {
+    "start": "tabris serve -w -a",
     "build": "tsc -p .",
     "watch": "tsc -p . -w --preserveWatchOutput --inlineSourceMap"
   }

--- a/examples/bind-two-way-change-events/src/ExampleComponent.tsx
+++ b/examples/bind-two-way-change-events/src/ExampleComponent.tsx
@@ -1,4 +1,4 @@
-import { ChangeListeners, Composite, Properties, Slider, StackComposite, TextInput, TextView } from 'tabris';
+import { ChangeListeners, Composite, Properties, Slider, Stack, TextInput, TextView } from 'tabris';
 import { bind, component, event } from 'tabris-decorators';
 
 @component
@@ -14,7 +14,7 @@ export class ExampleComponent extends Composite {
     super();
     this.set(properties);
     this.append(
-      <StackComposite spacing={12} padding={12} >
+      <Stack spacing={12} padding={12} >
 
         <TextView>Source of "myNumber":</TextView>
         <Slider id='source1' width={200}/>
@@ -22,7 +22,7 @@ export class ExampleComponent extends Composite {
         <TextView>Source of "myText":</TextView>
         <TextInput id='source2' width={200}/>
 
-      </StackComposite>
+      </Stack>
     );
     this._find(TextView).set({font: {size: 18}});
   }

--- a/examples/bind-two-way-change-events/src/app.tsx
+++ b/examples/bind-two-way-change-events/src/app.tsx
@@ -1,15 +1,15 @@
-import { contentView, ProgressBar, PropertyChangedEvent, StackComposite, TextView } from 'tabris';
+import { contentView, ProgressBar, PropertyChangedEvent, Stack, TextView } from 'tabris';
 import { ExampleComponent } from './ExampleComponent';
 
 contentView.append(
-  <StackComposite layoutData='fill' alignment='stretchX' padding={12} spacing={12}>
+  <Stack layoutData='stretch' alignment='stretchX' padding={12} spacing={12}>
     <ExampleComponent background='silver'
         onMyNumberChanged={updateProgressBar}
         onMyTextChanged={updateTextView}/>
     <TextView font='18px'>Current values:</TextView>
     <ProgressBar width={200}/>
     <TextView font='18px'/>
-  </StackComposite>
+  </Stack>
 );
 
 function updateProgressBar(ev: PropertyChangedEvent<ExampleComponent, number>) {

--- a/examples/bind-two-way/README.md
+++ b/examples/bind-two-way/README.md
@@ -1,0 +1,9 @@
+# Example "bind-two-way"
+
+Demonstrates the use of the `@bind` decorator to create two-way bindings between a custom component instance and its children. This app creates an instance of the included `ExampleComponent` class (grey background), which has properties that can be changed by interacting with the component. Below the component three is a button to change the property values of that instance, and one to print them on screen.
+
+The `ExampleComponent` the property `myNumber` is bound the `selection` property of a `Slider` with the id `source1`. Moving the slider changes the value of `myNumber`, as can be seen by pressing the "print current values" button. If `myNumber` is changed from outside the component - e.g. by pressing "change values", the slider position is updated accordingly.
+
+The other property `myText` is bound the `text` property of a `TextInput` with the id `source2`. Editing the text changes the value of `myText`, as can be seen by pressing the "print current values" button. If `myText` is changed from outside the component - e.g. by pressing "change values", the `TextInput` text is updated accordingly.
+
+Two-way bindings also require the `@component` decorator on the custom component class.

--- a/examples/bind-two-way/package.json
+++ b/examples/bind-two-way/package.json
@@ -1,14 +1,15 @@
 {
   "name": "bind-one-way",
-  "version": "3.0.0-rc1",
+  "version": "3.1.0",
   "dependencies": {
     "reflect-metadata": "^0.1.13",
-    "tabris": "3.0.0-rc1",
-    "tabris-decorators": "3.0.0-rc1",
+    "tabris": "^3.0.0",
+    "tabris-decorators": "^3.0.0",
     "typescript": "3.3.x"
   },
   "main": "dist/app.js",
   "scripts": {
+    "start": "tabris serve -w -a",
     "build": "tsc -p .",
     "watch": "tsc -p . -w --preserveWatchOutput --inlineSourceMap"
   }

--- a/examples/labeled-input/README.md
+++ b/examples/labeled-input/README.md
@@ -1,0 +1,7 @@
+# Example "labeled-input"
+
+Demonstrates the use of one-way and two-way bindings in realistic example component called `LabeledInput`. The component consists of a `TextView` with its `text` bound to the component `labelText` property (one-way) and a `TextInput` with its `text` bound to the component `text` property (two-way).
+
+In `app.tsx` two instances of the component are created. Entering text in the first one and hitting enter moves the focus to the second one. Entering text there and hitting enter again displays a message using the entered texts.
+
+One-way and two-way bindings require the `@component` decorator on the custom component class.

--- a/examples/labeled-input/package.json
+++ b/examples/labeled-input/package.json
@@ -1,14 +1,15 @@
 {
   "name": "labeled-input",
-  "version": "3.0.0-rc1",
+  "version": "3.1.0",
   "dependencies": {
     "reflect-metadata": "^0.1.13",
-    "tabris": "3.0.0-rc1",
-    "tabris-decorators": "3.0.0-rc1",
+    "tabris": "^3.0.0",
+    "tabris-decorators": "^3.0.0",
     "typescript": "3.3.x"
   },
   "main": "dist/app.js",
   "scripts": {
+    "start": "tabris serve -w -a",
     "build": "tsc -p .",
     "watch": "tsc -p . -w --preserveWatchOutput --inlineSourceMap"
   }

--- a/examples/property-change-events/README.md
+++ b/examples/property-change-events/README.md
@@ -1,0 +1,14 @@
+# Example "property-change-events"
+
+Demonstrates that properties decorated with `@property` trigger property change events on the target object. This app provides a UI to change the `name` and `age` properties (on button press) of an instance of the class `Person`. Doing so logs the changes in a on-screen label and in the developer console.
+
+Both `Person` properties are decorated with `@property` and have a matching `ChangeListeners` field. E.g. `age` is a property of the type `number` and `onAgeChanged` is of the type `ChangeListeners<Person, 'age'>`, indicating that it fires change events for the `age` property of `Person`. When the value of `age` is changed `@property` looks for `onAgeChanged` by name (`on`, followed by the upper case property name, followed by `Changed`) and triggers a matching change event.
+
+The `@event` decorator only creates the actual `ChangeListeners` instance, it is not required. The line
+```ts
+@event public onAgeChanged: ChangeListeners<Person, 'age'>;
+```
+could be replaced with:
+```ts
+public onAgeChanged: ChangeListeners<Person, 'age'> = new ChangeListeners(this, 'age');`
+```

--- a/examples/property-change-events/package.json
+++ b/examples/property-change-events/package.json
@@ -1,14 +1,15 @@
 {
   "name": "property-change-events",
-  "version": "3.0.0-rc1",
+  "version": "3.1.0",
   "dependencies": {
     "reflect-metadata": "^0.1.13",
-    "tabris": "3.0.0-rc1",
-    "tabris-decorators": "3.0.0-rc1",
+    "tabris": "^3.0.0",
+    "tabris-decorators": "^3.0.0",
     "typescript": "3.3.x"
   },
   "main": "dist/app.js",
   "scripts": {
+    "start": "tabris serve -w -a",
     "build": "tsc -p .",
     "watch": "tsc -p . -w --preserveWatchOutput --inlineSourceMap"
   }

--- a/examples/property-value-checks/README.md
+++ b/examples/property-value-checks/README.md
@@ -1,0 +1,13 @@
+# Example "property-value-checks"
+
+Demonstrates how `@property` can be used with type guards to narrow down the accepted values more than the type definition allows. This app provides a UI to change the `name` and `age` properties (on button press) of an instance of the class `Person`. Doing so only works if the age is a positive number and if the name has at least two characters.
+
+Both `Person` properties are decorated with `@property` which has one parameter - the type guard function. A type guard function is a function that takes one argument and returns a boolean indicating whether it is of a specific type or not. In this case the type guards also only allow a specific subset of that type:
+
+```ts
+function isPositiveNumber(value: any): value is number {
+  return value > 0 && isFinite(value) && !isNaN(value);
+}
+```
+
+Note that technically only functions with the special return syntax used above (`value is number`) are considered type guards by the TypeScript standard. However, `@property` does not care about this syntax, the return type could also be just `boolean`.

--- a/examples/property-value-checks/package.json
+++ b/examples/property-value-checks/package.json
@@ -1,14 +1,15 @@
 {
   "name": "property-value-checks",
-  "version": "3.0.0-rc1",
+  "version": "3.1.0",
   "dependencies": {
     "reflect-metadata": "^0.1.13",
-    "tabris": "3.0.0-rc1",
-    "tabris-decorators": "3.0.0-rc1",
+    "tabris": "^3.0.0",
+    "tabris-decorators": "^3.0.0",
     "typescript": "3.3.x"
   },
   "main": "dist/app.js",
   "scripts": {
+    "start": "tabris serve -w -a",
     "build": "tsc -p .",
     "watch": "tsc -p . -w --preserveWatchOutput --inlineSourceMap"
   }

--- a/examples/property-value-checks/src/Person.tsx
+++ b/examples/property-value-checks/src/Person.tsx
@@ -10,12 +10,12 @@ export class Person {
 
 }
 
-function isPositiveNumber(value: number) {
+function isPositiveNumber(value: any): value is number {
   return value > 0 && isFinite(value) && !isNaN(value);
 }
 
 function hasMinLength(length: number) {
-  return (value: string) => {
+  return (value: any): value is string => {
     if (!value || value.length < length) {
       throw new Error(`Expected string with at least ${length} character`);
     }

--- a/examples/property-value-checks/src/app.tsx
+++ b/examples/property-value-checks/src/app.tsx
@@ -1,16 +1,16 @@
-import { Button, contentView, StackComposite, TextInput, TextView } from 'tabris';
+import { Button, contentView, Stack, TextInput, TextView } from 'tabris';
 import { Person } from './Person';
 
 const person = new Person();
 
 contentView.append(
-  <StackComposite layoutData='fill' alignment='stretchX' padding={12} spacing={12}>
+  <Stack layoutData='stretch' alignment='stretchX' padding={12} spacing={12}>
     <TextInput text='X' message='Name (at least 2 chars)' onAccept={changeName}/>
     <Button onSelect={changeName}>Change Name</Button>
     <TextInput text='-5' message='Age (positive number)' onAccept={changeAge}/>
     <Button onSelect={changeAge}>Change Age</Button>
     <TextView font={{size: 18}}/>
-  </StackComposite>
+  </Stack>
 );
 
 function changeName() {

--- a/examples/tri-state-button/README.md
+++ b/examples/tri-state-button/README.md
@@ -1,0 +1,43 @@
+# Example "tri-state-button"
+
+Demonstrates the use of one-way and two-way bindings with [advanced types](https://www.typescriptlang.org/docs/handbook/advanced-types.html). It includes two example components, `TriStateButton` and `Survey`. The former component consists of a (emoji) icon and label. When tapped it cycles through three different states as indicated by the icon.
+
+This component is then used in the `Survey` component to give the user three yes/no questions with a third option to remain neutral. The answers are available on public properties of `Survey` via two-way bindings. In `app.tsx` they are read when the "print results" button is pressed.
+
+The "advanced types" used in these components are the `State` union type (consisting of `boolean` and the value string `'neutral'`, defined in the `TriStateButton` module), as well as `ColorValue` and `FontValue` (unions of various types, provided by the `'tabris'` module). The data binding mechanism in `tabris-decorators` performs type checks each time a value in a binding is updated. In case of primitive types (such as `string`) and class types (such as `Date`) this works out of the box. Mixed[1] unions, intersection and interface types do require explicit type guards provided by the application code, otherwise the binding fails with an error.
+
+For one-way bindings these type guards are required only on the target property, but two-way bindings need both ends to use them.
+
+When using the `@property` decorator the type guard can be given as the sole parameter, as can be seen in the `TriStateButton` where the `isState` type guard function is implemented and applied in this line:
+
+```ts
+@property(isState) public state: State = false;
+```
+
+The `textColor` and `font` properties can use the type guards for their respective types provided by the `'tabris'` module:
+
+```ts
+@property(Color.isColorValue) public textColor: ColorValue = 'black';
+```
+
+A property with `@bind` needs to provide a parameter object with a `typeGuard` entry, as seen in the `Survey` component:
+
+```ts
+@bind({path: '#pizza.state', typeGuard: isState})
+public pizza: State;
+```
+
+If a property is implemented with explicit setter and getter the type guard must be called explicitly in the setter. However, this is not enforced. Here is how an explicit setter for the `TriStateButton` property `textColor` would look like:
+
+```ts
+  public set textColor(value: ColorValue) {
+    if (!Color.isColorValue(value)) {
+      throw new Error('Invalid value ' + value);
+    }
+    this._find(TextView).last(TextView).textColor = value;
+  }
+```
+
+One-way and two-way bindings require the `@component` decorator on the custom component class.
+
+[1] "Mixed" meaning that a union consists of different types, not just different values of the same type. Such non-"mixed" unions, like enums, can be used for data binding without type guards, but the automatic checks only ensure that the primitive type matches. For example, if `State` was defined as `'checked' | 'crossed' | 'neutral'` - which is arguably more sensible than mixing boolean and string - the type guard would not be enforced. It would however (incorrectly) allow binding a `string` property to a `State` property. In this specific case a type guard should be provided even though it is not enforced.

--- a/examples/tri-state-button/package.json
+++ b/examples/tri-state-button/package.json
@@ -1,14 +1,15 @@
 {
-  "name": "bind-one-way",
-  "version": "3.0.0-rc1",
+  "name": "tri-state-button",
+  "version": "3.1.0",
   "dependencies": {
     "reflect-metadata": "^0.1.13",
-    "tabris": "3.0.0-rc1",
-    "tabris-decorators": "3.0.0-rc1",
-    "typescript": "3.4.x"
+    "tabris": "^3.0.0",
+    "tabris-decorators": "^3.0.0",
+    "typescript": "3.3.x"
   },
   "main": "dist/app.js",
   "scripts": {
+    "start": "tabris serve -w -a",
     "build": "tsc -p .",
     "watch": "tsc -p . -w --preserveWatchOutput --inlineSourceMap"
   }

--- a/examples/tri-state-button/src/TriStateButton.tsx
+++ b/examples/tri-state-button/src/TriStateButton.tsx
@@ -1,16 +1,16 @@
 import { Color, ColorValue, Composite, Font, FontValue, LayoutData, Properties, TextView } from 'tabris';
 import { component, property, to } from 'tabris-decorators';
 
-export type State = 'empty' | 'checked' | 'crossed';
+export type State = boolean | 'neutral';
 
 export function isState(value: unknown): value is State {
-  return value === 'empty' || value === 'checked' || value === 'crossed';
+  return value === true || value === false || value === 'neutral';
 }
 
 @component
 export class TriStateButton extends Composite {
 
-  @property(isState) public state: State = 'empty';
+  @property(isState) public state: State = false;
   @property(Color.isColorValue) public textColor: ColorValue = 'black';
   @property(Font.isFontValue) public font: FontValue = 'initial';
   @property public text: string = '';
@@ -21,7 +21,7 @@ export class TriStateButton extends Composite {
     this.onTap(this.handleTap);
     this.append(
       <$>
-        <TextView centerY font={{size: 24}} bind-text={to('state', state => stateToChar[state])}/>
+        <TextView centerY font={{size: 24}} bind-text={to('state', stateToChar)}/>
         <TextView centerY left={[LayoutData.prev, 8]}
             bind-text='text'
             bind-font='font'
@@ -31,19 +31,22 @@ export class TriStateButton extends Composite {
   }
 
   private handleTap = () => {
-    if (this.state === 'checked') {
-      this.state = 'crossed';
-    } else if (this.state === 'crossed') {
-      this.state = 'empty';
+    if (this.state === true) {
+      this.state = false;
+    } else if (this.state === false) {
+      this.state = 'neutral';
     } else {
-      this.state = 'checked';
+      this.state = true;
     }
   }
 
 }
 
-const stateToChar: Record<State, string> = {
-  empty: '☐',
-  checked: '☑',
-  crossed: '☒'
-};
+function stateToChar(state: State) {
+  if (state === 'neutral') {
+    return '☐';
+  } else if (state === true) {
+    return '☑';
+  }
+  return '☒';
+}

--- a/examples/tri-state-button/src/app.tsx
+++ b/examples/tri-state-button/src/app.tsx
@@ -4,7 +4,7 @@ import { State } from './TriStateButton';
 
 contentView.append(
   <Stack stretch alignment='stretchX' padding={12} spacing={12}>
-    <Survey textColor='red' font='18px serif'/>
+    <Survey textColor={{red: 255, green: 10, blue: 10}} font='18px serif' apples milk/>
     <Button onSelect={printResults}>Print results</Button>
     <TextView markupEnabled font='18px serif'/>
   </Stack>
@@ -22,10 +22,10 @@ function printResults() {
 }
 
 function stateToAnswer(state: State) {
-  if (state === 'checked') {
+  if (state === true) {
     return 'Yes';
   }
-  if (state === 'crossed') {
+  if (state === false) {
     return 'No';
   }
   return '(No answer)';

--- a/src/decorators/bind.ts
+++ b/src/decorators/bind.ts
@@ -35,5 +35,5 @@ export function bind(...args: any[]): any {
 
 export interface BindConfig {
   path: string;
-  typeGuard: TypeGuard;
+  typeGuard?: TypeGuard;
 }


### PR DESCRIPTION
* Update all examples for tabris 3.0 (they were still on 3.0-rc1)
* Add start scripts to all package.json
* Add README.md explaining the examples in detail
* Update property-value-checks to use actual type guard syntax
* Update tri-state-button to create a case that enforces type guards

Minor interface fix in bind.ts