### PR TITLE
Support non-widget change events in one-way bindings

### DIFF
--- a/examples/bind-one-way/src/ExampleComponent.tsx
+++ b/examples/bind-one-way/src/ExampleComponent.tsx
@@ -1,9 +1,13 @@
 import { Composite, ProgressBar, Properties, Stack, TextView } from 'tabris';
 import { component, property } from 'tabris-decorators';
 
+export class OtherModel {
+  @property public someString: string = 'Hello World';
+}
+
 export class Model {
-  public someString: string = 'Hello Again!';
-  public someNumber: number = 50;
+  @property public otherModel: OtherModel = new OtherModel();
+  @property public someNumber: number = 10;
 }
 
 @component
@@ -18,26 +22,18 @@ export class ExampleComponent extends Composite {
     this.append(
       <Stack spacing={12} padding={12} >
 
-        <TextView>Simple binding to a string property:</TextView>
-        <TextView bind-text='myText'/>
+        <TextView>Binding to a component property:</TextView>
+        <TextView background='yellow'
+            bind-text='myText'
+            text='Placeholder'/>
 
-        <TextView>Exactly the same:</TextView>
-        <TextView bind-text={{path: 'myText'}}/>
-
-        <TextView>With a fallback value for undefined:</TextView>
-        <TextView text='fallback text' bind-text='myText'/>
-
-        <TextView>To the property of an object:</TextView>
-        <TextView bind-text='myObject.someString'/>
-
-        <TextView>With a fallback value for null or undefined:</TextView>
-        <TextView text='fallback text' bind-text='myObject.someString'/>
-
-        <TextView>Binding to a numeric value:</TextView>
+        <TextView>Binding to a object property:</TextView>
         <ProgressBar bind-selection='myObject.someNumber' width={200}/>
 
-        <TextView>Binding to a numeric value with fallback:</TextView>
-        <ProgressBar selection={100} bind-selection='myObject.someNumber' width={200}/>
+        <TextView>Binding to a nested object property:</TextView>
+        <TextView background='yellow'
+            bind-text='myObject.otherModel.someString'
+            text='Placeholder'/>
 
       </Stack>
     );

--- a/examples/bind-one-way/src/app.tsx
+++ b/examples/bind-one-way/src/app.tsx
@@ -1,16 +1,28 @@
 import { CheckBox, CheckBoxSelectEvent, Color, contentView, Stack } from 'tabris';
 import { ExampleComponent, Model } from './ExampleComponent';
 
+const model = new Model();
+
 contentView.append(
   <Stack stretch alignment='stretchX' padding={12} spacing={12}>
-    <CheckBox font={{size: 24}} onSelect={toggleValues}>Toggle Values</CheckBox>
+    <CheckBox font={{size: 24}} onSelect={toggleComponentValues}>
+      Toggle Component Values
+    </CheckBox>
+    <CheckBox font={{size: 24}} onSelect={toggleModelValues}>
+      Toggle Model Values
+    </CheckBox>
     <ExampleComponent background={Color.silver}/>
   </Stack>
 );
 
-function toggleValues({checked}: CheckBoxSelectEvent) {
+function toggleComponentValues({checked}: CheckBoxSelectEvent) {
   $(ExampleComponent).set({
-    myText: checked ? 'Hello World' : undefined,
-    myObject: checked ? new Model() : null
+    myText: checked ? 'My Text' : undefined,
+    myObject: checked ? model : null
   });
+}
+
+function toggleModelValues({checked}: CheckBoxSelectEvent) {
+  model.someNumber = checked ? 90 : 10;
+  model.otherModel.someString = checked ? 'Another Hello' : 'Hello World';
 }

--- a/src/internals/subscribe.ts
+++ b/src/internals/subscribe.ts
@@ -1,0 +1,70 @@
+import { Listeners } from 'tabris';
+import { supportsChangeEvents } from './utils';
+
+const force = Symbol();
+
+export function subscribe(root: any, path: string[], cb: (value: unknown) => void) {
+  checkParameter(root, path, cb);
+  const [rootProperty, ...subProperties] = path;
+  let currentValue;
+  let cancel;
+  const listener = (mode: any) => {
+    if ((mode === force) || (currentValue !== root[rootProperty])) {
+      currentValue = root[rootProperty];
+      if (subProperties.length) {
+        if (cancel) {
+          cancel();
+        }
+        if (currentValue && (currentValue instanceof Object)) {
+          cancel = subscribe(currentValue, subProperties, cb);
+        } else if (currentValue == null) {
+          cb(undefined);
+        } else {
+          throw new TypeError(
+            `Value of property "${rootProperty}" is of type ${typeof currentValue}, expected object`
+          );
+        }
+      } else {
+        cb(currentValue);
+      }
+    }
+  };
+  addChangeListener(root, rootProperty, listener);
+  listener(force);
+  return () => {
+    removeChangeListener(root, rootProperty, listener);
+    if (cancel) {
+      cancel();
+    }
+  };
+}
+
+function checkParameter(root: any, path: string[], cb: (value: unknown) => void) {
+  if (!(root instanceof Object)) {
+    throw new Error('root is not an Object');
+  }
+  if (!(path instanceof Array)) {
+    throw new Error('path is not an Array');
+  }
+  if (path.length === 0) {
+    throw new Error('path is not an Array');
+  }
+  if (path.some(entry => !entry)) {
+    throw new Error('path contains invalid entries');
+  }
+  if (!(cb instanceof Function)) {
+    throw new Error('callback is not a function');
+  }
+}
+
+function addChangeListener(target: any, property: string, listener: (value: unknown) => void) {
+  if (supportsChangeEvents(target, property)) {
+    Listeners.getListenerStore(target).on(property + 'Changed', listener);
+  }
+}
+
+function removeChangeListener(target: any, property: string, listener: (value: unknown) => void) {
+  if (supportsChangeEvents(target, property)) {
+    Listeners.getListenerStore(target).off(property + 'Changed', listener);
+  }
+}

--- a/test/subscribe.spec.ts
+++ b/test/subscribe.spec.ts
@@ -1,0 +1,335 @@
+import 'mocha';
+import 'sinon';
+import { SinonSpy } from 'sinon';
+import { ChangeListeners, Composite, Listeners, tabris, TextInput, TextView, WidgetCollection } from 'tabris';
+import ClientMock from 'tabris/ClientMock';
+import { expect, restoreSandbox, spy, stub } from './test';
+import { property } from '../src';
+import { subscribe } from '../src/internals/subscribe';
+/* tslint:disable:no-unused-expression max-classes-per-file max-file-line-count no-empty*/
+
+describe('subscribe', () => {
+
+  beforeEach(() => {
+    tabris._init(new ClientMock());
+  });
+
+  describe('parameter check', () => {
+
+    it('throws with falsy root', () => {
+      expect(() => subscribe(undefined, ['foo', 'bar'], () => {})).to.throw();
+      expect(() => subscribe(null, ['foo', 'bar'], () => {})).to.throw();
+    });
+
+    it('throws with falsy path', () => {
+      expect(() => subscribe({}, undefined, () => {})).to.throw();
+      expect(() => subscribe({}, null, () => {})).to.throw();
+    });
+
+    it('throws with path containing falsy entries', () => {
+      expect(() => subscribe({}, [], () => {})).to.throw();
+      expect(() => subscribe({}, [null], () => {})).to.throw();
+      expect(() => subscribe({}, [undefined], () => {})).to.throw();
+      expect(() => subscribe({}, ['foo', undefined], () => {})).to.throw();
+      expect(() => subscribe({}, [''], () => {})).to.throw();
+    });
+
+    it('throws with falsy callback', () => {
+      expect(() => subscribe({}, ['foo'], null)).to.throw();
+      expect(() => subscribe({}, ['foo'], undefined)).to.throw();
+    });
+
+    it('does not throws with valid arguments', () => {
+      expect(() => subscribe({}, ['foo'], () => {})).not.to.throw();
+    });
+
+  });
+
+  describe('widget property subscriber', () => {
+
+    let widget: Composite;
+    let sub: SinonSpy;
+    let cancel: () => void;
+
+    beforeEach(() => {
+      widget = new Composite();
+      widget.cornerRadius = 10;
+      sub = spy();
+      cancel = subscribe(widget, ['cornerRadius'], sub);
+    });
+
+    it('is called initially with current value', () => {
+      expect(sub).to.have.been.calledOnce;
+      expect(sub).to.have.been.calledWith(10);
+    });
+
+    it('is called with new value', () => {
+      sub.reset();
+      widget.cornerRadius = 5;
+      expect(sub).to.have.been.calledWith(5);
+    });
+
+    it('is not called after cancellation', () => {
+      sub.reset();
+
+      cancel();
+      widget.cornerRadius = 5;
+
+      expect(sub).not.to.have.been.called;
+    });
+
+  });
+
+  describe('plain object property subscriber', () => {
+
+    type Target = {foo: string, onFooChanged?: ChangeListeners<Target, 'foo'>};
+    let target: Target;
+    let sub: SinonSpy;
+
+    beforeEach(() => {
+      target = {foo: 'bar'};
+      sub = spy();
+    });
+
+    it('is called initially with current value', () => {
+      subscribe(target, ['foo'], sub);
+      expect(sub).to.have.been.calledOnce;
+      expect(sub).to.have.been.calledWith('bar');
+    });
+
+    it('is not automatically called with new value', () => {
+      subscribe(target, ['foo'], sub);
+      sub.reset();
+      target.foo = 'baz';
+      expect(sub).not.to.have.been.called;
+    });
+
+    it('is called with new value if ChangeListeners is set up correctly', () => {
+      target.onFooChanged = new ChangeListeners(target, 'foo');
+      subscribe(target, ['foo'], sub);
+      sub.reset();
+
+      target.foo = 'baz';
+      target.onFooChanged.trigger({value: target.foo});
+
+      expect(sub).to.have.been.calledOnce;
+      expect(sub).to.have.been.calledWith('baz');
+    });
+
+    it('is called with new value if Listeners is used correctly', () => {
+      target.onFooChanged = new Listeners(target, 'fooChanged');
+      subscribe(target, ['foo'], sub);
+      sub.reset();
+
+      target.foo = 'baz';
+      target.onFooChanged.trigger({value: target.foo});
+
+      expect(sub).to.have.been.calledOnce;
+      expect(sub).to.have.been.calledWith('baz');
+    });
+
+    it('is called with new value if trigger is called without parameter', () => {
+      target.onFooChanged = new Listeners(target, 'fooChanged');
+      subscribe(target, ['foo'], sub);
+      sub.reset();
+
+      target.foo = 'baz';
+      target.onFooChanged.trigger();
+
+      expect(sub).to.have.been.calledOnce;
+      expect(sub).to.have.been.calledWith('baz');
+    });
+
+    it('is not called if trigger is called without value change', () => {
+      target.onFooChanged = new Listeners(target, 'fooChanged');
+      subscribe(target, ['foo'], sub);
+      sub.reset();
+
+      target.onFooChanged.trigger();
+
+      expect(sub).not.to.have.been.called;
+    });
+
+    it('throws if Listeners is not set up with correct target', () => {
+      target.onFooChanged = new Listeners({foo: 'bar'}, 'fooChanged');
+      expect(() => subscribe(target, ['foo'], sub)).to.throw();
+    });
+
+    it('throws if Listeners is not set up with correct type', () => {
+      target.onFooChanged = new Listeners(target, 'barChanged');
+      expect(() => subscribe(target, ['foo'], sub)).to.throw();
+    });
+
+    it('is not called with new value if ChangeListeners is created later', () => {
+      subscribe(target, ['foo'], sub);
+      target.onFooChanged = new ChangeListeners(target, 'foo');
+      sub.reset();
+
+      target.foo = 'baz';
+      target.onFooChanged.trigger({value: target.foo});
+
+      expect(sub).not.to.have.been.called;
+    });
+
+    it('is not given to non-Listeners function', () => {
+      const notListeners = spy();
+      target.onFooChanged = notListeners as any;
+
+      subscribe(target, ['foo'], sub);
+
+      expect(notListeners).not.to.have.been.called;
+    });
+
+  });
+
+  describe('@property subscriber', () => {
+
+    class ModelA {
+      @property public foo: number;
+      @property(() => true)
+      public b: any;
+    }
+
+    class ModelB {
+      @property public bar: string;
+      @property public a: ModelA;
+    }
+
+    let target: ModelA;
+    let sub: SinonSpy;
+    let cancel: () => void;
+
+    beforeEach(() => {
+      target = new ModelA();
+      sub = spy();
+    });
+
+    describe('to primitive type', () => {
+
+      it('is called initially with current value', () => {
+        target.foo = 1;
+
+        subscribe(target, ['foo'], sub);
+
+        expect(sub).to.have.been.calledOnce;
+        expect(sub).to.have.been.calledWith(1);
+      });
+
+      it('is called with new value', () => {
+        subscribe(target, ['foo'], sub);
+        sub.reset();
+
+        target.foo = 2;
+
+        expect(sub).to.have.been.calledOnce;
+        expect(sub).to.have.been.calledWith(2);
+      });
+
+      it('is called with undefined for non-existing property', () => {
+        subscribe(target, ['baz'], sub);
+        expect(sub).to.have.been.calledWith(undefined);
+      });
+
+      it('is called with non-initialized property value', () => {
+        subscribe(target, ['foo'], sub);
+        expect(sub).to.have.been.calledWith(undefined);
+      });
+
+      it('is not called after cancellation', () => {
+        cancel = subscribe(target, ['foo'], sub);
+        sub.reset();
+
+        cancel();
+        target.foo = 2;
+
+        expect(sub).not.to.have.been.called;
+      });
+
+    });
+
+    describe('to nested target', () => {
+
+      let subTarget: ModelB;
+
+      beforeEach(() => {
+        subTarget = new ModelB();
+        subTarget.bar = 'baz';
+        target.b = subTarget;
+        cancel = subscribe(target, ['b', 'bar'], sub);
+      });
+
+      it('is called initially with current value', () => {
+        expect(sub).to.have.been.calledOnce;
+        expect(sub).to.have.been.calledWith('baz');
+      });
+
+      it('is called when sub-target property changes', () => {
+        sub.reset();
+
+        subTarget.bar = 'hello';
+
+        expect(sub).to.have.been.calledOnce;
+        expect(sub).to.have.been.calledWith('hello');
+      });
+
+      it('is called when sub-target is replaced', () => {
+        sub.reset();
+
+        const newSubTarget = new ModelB();
+        newSubTarget.bar = 'world';
+        target.b = newSubTarget;
+
+        expect(sub).to.have.been.calledOnce;
+        expect(sub).to.have.been.calledWith('world');
+      });
+
+      it('is called when sub-target is set', () => {
+        sub.reset();
+        target.b = null;
+
+        target.b = subTarget;
+
+        expect(sub).to.have.been.calledTwice;
+        expect(sub).to.have.been.calledWith(undefined);
+        expect(sub).to.have.been.calledWith('baz');
+      });
+
+      it('is called with undefined when sub-target is set to null', () => {
+        sub.reset();
+
+        target.b = null;
+
+        expect(sub).to.have.been.calledOnce;
+        expect(sub).to.have.been.calledWith(undefined);
+      });
+
+      it('throws when sub-target is set to non-object', () => {
+        expect(() => target.b = 'foo').to.throw(
+          TypeError,
+          'Value of property "b" is of type string, expected object'
+        );
+      });
+
+      it('is not called when previous sub-target property changes', () => {
+        target.b = null;
+        sub.reset();
+
+        subTarget.bar = 'world';
+
+        expect(sub).not.to.have.been.called;
+      });
+
+      it('is not called after cancellation', () => {
+        sub.reset();
+
+        cancel();
+        subTarget.bar = 'world';
+
+        expect(sub).not.to.have.been.called;
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
Make one-way bindings recognize change events on non-widget objects. Due
to the recursive manner of the internal "subscribe" method the binding
paths may now also have any depth.

Change events are recognized on plain objects if they either use
@property or if they expose an appropriately configured Listeners
interface. If no change events are provided the binding still works,
just without change detection.

Update documentation and the bind-one-way example.