### PR TITLE
Fix examples using removed "strictMode" property

### DIFF
--- a/examples/bind-and-convert-jsx/package.json
+++ b/examples/bind-and-convert-jsx/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-and-convert/package.json
+++ b/examples/bind-and-convert/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-and-convert/src/app.tsx
+++ b/examples/bind-and-convert/src/app.tsx
@@ -2,7 +2,7 @@ import {CheckBox, CheckBoxSelectEvent, Color, contentView, Stack} from 'tabris';
 import {injector} from 'tabris-decorators';
 import {ExampleComponent} from './ExampleComponent';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 const time1 = new Date(0, 0, 0, 10, 30);
 const time2 = new Date(0, 0, 0, 22, 45);

--- a/examples/bind-itempicker-list-jsx/package.json
+++ b/examples/bind-itempicker-list-jsx/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-itempicker-list/package.json
+++ b/examples/bind-itempicker-list/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-itempicker-list/src/app.tsx
+++ b/examples/bind-itempicker-list/src/app.tsx
@@ -3,7 +3,7 @@ import {injector, List} from 'tabris-decorators';
 import {ExampleComponent} from './ExampleComponent';
 import {generate, Person} from './Person';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 const items: List<Person> = List.from(generate(10));
 

--- a/examples/bind-listview-array-jsx/package.json
+++ b/examples/bind-listview-array-jsx/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-listview-array/package.json
+++ b/examples/bind-listview-array/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-listview-array/src/app.tsx
+++ b/examples/bind-listview-array/src/app.tsx
@@ -2,7 +2,7 @@ import {Color, contentView, Stack, TextView} from 'tabris';
 import {injector} from 'tabris-decorators';
 import {ExampleComponent} from './ExampleComponent';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 let count = 0;
 let items: string[] = Array.from(generate(20));

--- a/examples/bind-listview-list-jsx/package.json
+++ b/examples/bind-listview-list-jsx/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-listview-list/src/app.tsx
+++ b/examples/bind-listview-list/src/app.tsx
@@ -2,7 +2,7 @@ import {Color, contentView, Stack, TextView} from 'tabris';
 import {injector, List} from 'tabris-decorators';
 import {ExampleComponent} from './ExampleComponent';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 let count = 0;
 const items: List<string> = List.from(generate(20));

--- a/examples/bind-one-way-jsx/package.json
+++ b/examples/bind-one-way-jsx/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-one-way/package.json
+++ b/examples/bind-one-way/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-one-way/src/app.tsx
+++ b/examples/bind-one-way/src/app.tsx
@@ -2,7 +2,7 @@ import {CheckBox, CheckBoxSelectEvent, Color, contentView, Stack} from 'tabris';
 import {injector} from 'tabris-decorators';
 import {ExampleComponent, Model} from './ExampleComponent';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 const model = new Model();
 

--- a/examples/bind-two-way-change-events-jsx/package.json
+++ b/examples/bind-two-way-change-events-jsx/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.0",
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-two-way-change-events/package.json
+++ b/examples/bind-two-way-change-events/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-two-way-change-events/src/app.tsx
+++ b/examples/bind-two-way-change-events/src/app.tsx
@@ -2,7 +2,7 @@ import {contentView, ProgressBar, PropertyChangedEvent, Stack, TextView} from 't
 import {injector} from 'tabris-decorators';
 import {ExampleComponent, Model} from './ExampleComponent';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 const model = new Model();
 

--- a/examples/bind-two-way-jsx/package.json
+++ b/examples/bind-two-way-jsx/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-two-way-model-jsx/package.json
+++ b/examples/bind-two-way-model-jsx/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-two-way-model/package.json
+++ b/examples/bind-two-way-model/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-two-way-model/src/app.tsx
+++ b/examples/bind-two-way-model/src/app.tsx
@@ -2,7 +2,7 @@ import {Button, CheckBox, CheckBoxSelectEvent, Color, contentView, Stack, TextVi
 import {injector} from 'tabris-decorators';
 import {ExampleComponent, Model} from './ExampleComponent';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 const model = new Model();
 resetValues();

--- a/examples/bind-two-way/package.json
+++ b/examples/bind-two-way/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/bind-two-way/src/app.tsx
+++ b/examples/bind-two-way/src/app.tsx
@@ -2,7 +2,7 @@ import {Button, contentView, Stack, TextView} from 'tabris';
 import {injector} from 'tabris-decorators';
 import {ExampleComponent} from './ExampleComponent';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 contentView.append(
   <Stack stretch alignment='stretchX' padding={12} spacing={12}>

--- a/examples/itempicker-jsx/package.json
+++ b/examples/itempicker-jsx/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/itempicker/package.json
+++ b/examples/itempicker/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/itempicker/src/app.tsx
+++ b/examples/itempicker/src/app.tsx
@@ -1,7 +1,7 @@
 import {contentView, Stack, TextView} from 'tabris';
 import {injector, ItemPicker, ItemPickerSelectEvent, List} from 'tabris-decorators';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 class Item {
 

--- a/examples/labeled-input-jsx/package.json
+++ b/examples/labeled-input-jsx/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/labeled-input/package.json
+++ b/examples/labeled-input/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/labeled-input/src/app.tsx
+++ b/examples/labeled-input/src/app.tsx
@@ -2,7 +2,7 @@ import {AlertDialog, contentView} from 'tabris';
 import {injector} from 'tabris-decorators';
 import {LabeledInput} from './LabeledInput';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 contentView.append(
   <$>

--- a/examples/listview-cells-jsx/package.json
+++ b/examples/listview-cells-jsx/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/listview-cells-jsx/src/app.jsx
+++ b/examples/listview-cells-jsx/src/app.jsx
@@ -1,7 +1,7 @@
 import {Button, CheckBox, Color, Composite, contentView, StackLayout, Tab, TabFolder, TextView} from 'tabris';
 import {Cell, injector, ItemAction, ListView, property, to} from 'tabris-decorators';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 class Item {
 

--- a/examples/listview-cells/package.json
+++ b/examples/listview-cells/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/listview-cells/src/app.tsx
+++ b/examples/listview-cells/src/app.tsx
@@ -1,7 +1,7 @@
 import {Button, CheckBox, Color, Composite, contentView, PropertyChangedEvent, StackLayout, Tab, TabFolder, TextView} from 'tabris';
 import {Cell, injector, ItemAction, ListView, ListViewSelectEvent, property, to} from 'tabris-decorators';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 class Item {
   @property text: string;

--- a/examples/property-change-events-jsx/package.json
+++ b/examples/property-change-events-jsx/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/property-change-events-jsx/src/app.jsx
+++ b/examples/property-change-events-jsx/src/app.jsx
@@ -2,7 +2,7 @@ import {Button, contentView, Slider, Stack, TextInput, TextView} from 'tabris';
 import {injector} from 'tabris-decorators';
 import {Person} from './Person';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 const person = new Person();
 person.age = 22;

--- a/examples/property-change-events/package.json
+++ b/examples/property-change-events/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/property-change-events/src/app.tsx
+++ b/examples/property-change-events/src/app.tsx
@@ -2,7 +2,7 @@ import {Button, contentView, Slider, Stack, TextInput, TextView} from 'tabris';
 import {injector} from 'tabris-decorators';
 import {Person} from './Person';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 const person = new Person();
 person.age = 22;

--- a/examples/property-value-checks-jsx/package.json
+++ b/examples/property-value-checks-jsx/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/property-value-checks-jsx/src/app.jsx
+++ b/examples/property-value-checks-jsx/src/app.jsx
@@ -2,7 +2,7 @@ import {Button, contentView, Stack, TextInput, TextView} from 'tabris';
 import {injector} from 'tabris-decorators';
 import {Person} from './Person';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 const person = new Person();
 

--- a/examples/property-value-checks/package.json
+++ b/examples/property-value-checks/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/property-value-checks/src/app.tsx
+++ b/examples/property-value-checks/src/app.tsx
@@ -2,7 +2,7 @@ import {Button, contentView, Stack, TextInput, TextView} from 'tabris';
 import {injector} from 'tabris-decorators';
 import {Person} from './Person';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 const person = new Person();
 

--- a/examples/tri-state-button-jsx/package.json
+++ b/examples/tri-state-button-jsx/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/tri-state-button-jsx/src/app.jsx
+++ b/examples/tri-state-button-jsx/src/app.jsx
@@ -2,7 +2,7 @@ import {Button, contentView, Stack, TextView} from 'tabris';
 import {injector} from 'tabris-decorators';
 import {Survey} from './Survey';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 contentView.append(
   <Stack stretch alignment='stretchX' padding={12} spacing={12}>

--- a/examples/tri-state-button/package.json
+++ b/examples/tri-state-button/package.json
@@ -6,7 +6,7 @@
   },
   "optionalDependencies": {
     "tabris": "^3.3.0",
-    "tabris-decorators": "3.3.0"
+    "tabris-decorators": "3.4.0"
   },
   "devDependencies": {
     "typescript": "3.3.x"

--- a/examples/tri-state-button/src/app.tsx
+++ b/examples/tri-state-button/src/app.tsx
@@ -3,7 +3,7 @@ import {injector} from 'tabris-decorators';
 import {Survey} from './Survey';
 import {State} from './TriStateButton';
 
-injector.jsxProcessor.strictMode = true;
+injector.jsxProcessor.unsafeBindings = 'error';
 
 contentView.append(
   <Stack stretch alignment='stretchX' padding={12} spacing={12}>


### PR DESCRIPTION
This property was changed to "unsafeBindings" before release.

Also update all example dependencies to tabris-decorators to version
3.4.0.