### PR TITLE
Refactor @property

### DIFF
--- a/src/decorators/bind.ts
+++ b/src/decorators/bind.ts
@@ -1,9 +1,10 @@
 import {Composite} from 'tabris';
 import {property} from './property';
 import {Injector, injector} from '../api/Injector';
+import {CustomPropertyDescriptor} from '../internals/CustomPropertyDescriptor';
 import {TwoWayBinding} from '../internals/TwoWayBinding';
 import {applyDecorator, getPropertyType, isPrimitiveType} from '../internals/utils';
-import {checkIsComponent, checkPropertyExists, isUnchecked, parseTargetPath, postAppendHandlers, TargetPath, TypeGuard, UserType, WidgetInterface} from '../internals/utils-databinding';
+import {checkIsComponent, checkPropertyExists, parseTargetPath, postAppendHandlers, TargetPath, TypeGuard, UserType, WidgetInterface} from '../internals/utils-databinding';
 
 export interface BindAllConfig<ValidKeys extends string> {
   typeGuard?: TypeGuard;
@@ -154,7 +155,7 @@ function createBindAllTypeGuard(binding: BindSuperConfig) {
       const className = binding.componentProto.constructor.name;
       for (const sourceProperty of sourceProperties) {
         checkPropertyExists(value, sourceProperty, 'Object');
-        if (isUnchecked(value, sourceProperty)) {
+        if (CustomPropertyDescriptor.isUnchecked(value, sourceProperty)) {
           const strictMode = Injector.get(value, injector).jsxProcessor.unsafeBindings === 'error';
           if (strictMode) {
             throw new Error(`Object property "${sourceProperty}" requires an explicit type check.`);

--- a/src/internals/CustomPropertyDescriptor.ts
+++ b/src/internals/CustomPropertyDescriptor.ts
@@ -1,0 +1,101 @@
+import {Constructor, getPropertyType} from './utils';
+import {getPropertyStore, trigger} from './utils-databinding';
+import {checkType} from '../api/checkType';
+import {PropertySuperConfig} from '../decorators/property';
+
+export class CustomPropertyDescriptor<Proto extends object, TargetType> {
+
+  private static readonly metaDataKey = Symbol();
+
+  static get<Proto extends object, TargetType>(
+    proto: Proto,
+    propertyName: keyof Proto & string
+  ): CustomPropertyDescriptor<Proto, TargetType> {
+    let descriptor = Reflect.getMetadata(this.metaDataKey, proto, propertyName);
+    if (!descriptor) {
+      descriptor = new CustomPropertyDescriptor(proto, propertyName);
+      Reflect.defineMetadata(this.metaDataKey, descriptor, proto, propertyName);
+    }
+    else if (!(descriptor instanceof CustomPropertyDescriptor)) {
+      throw new Error(`Property "${descriptor}" can not be re-defined`);
+    }
+    return descriptor as CustomPropertyDescriptor<Proto, TargetType>;
+  }
+
+  static isUnchecked<PropertyName extends string>(
+    target: object,
+    propertyName: PropertyName
+  ): boolean {
+    const desc = Reflect.getMetadata(this.metaDataKey, target, propertyName);
+    if (desc instanceof CustomPropertyDescriptor) {
+      return desc.unchecked;
+    }
+    return false;
+  }
+
+  static has<PropertyName extends string>(target: any, propertyName: PropertyName): target is {
+    [name in PropertyName]: any;
+  } {
+    return !!Reflect.getMetadata(this.metaDataKey, target, propertyName);
+  }
+
+  readonly enumerable = true;
+  readonly configurable = true;
+  readonly get: () => TargetType;
+  readonly set: (value: TargetType) => void;
+  private readonly changeEvent: string;
+  private readonly targetType: Constructor<TargetType>;
+  private readonly config: Array<PropertySuperConfig<TargetType>> = [];
+  private unchecked: boolean;
+
+  constructor(private readonly proto: Proto, private readonly propertyName: keyof Proto & string) {
+    const self = this;
+    this.changeEvent = propertyName + 'Changed';
+    this.targetType = getPropertyType(this.proto, this.propertyName);
+    this.unchecked = this.targetType as Constructor<any> === Object;
+    this.set = function(this: Proto, value) { self.setValue(this, value); };
+    this.get = function(this: Proto) { return self.getValue(this); };
+    Object.defineProperty(proto, propertyName, this);
+  }
+
+  addConfig(config: PropertySuperConfig<TargetType>) {
+    if (config.type || config.typeGuard) {
+      this.unchecked = false;
+    }
+    this.config.push(config);
+  }
+  private getValue(instance: Proto) {
+    return getPropertyStore(instance).get(this.propertyName);
+  }
+
+  private setValue(instance: Proto, value: any) {
+    const currentValue = this.getValue(instance);
+    if (currentValue !== value) {
+      if (!this.unchecked) {
+        this.checkType(value);
+      }
+      getPropertyStore(instance).set(this.propertyName, value);
+      trigger(instance, this.changeEvent, {value});
+    }
+  }
+
+  private checkType(value: any) {
+    try {
+      if (this.config[0].type) { // unlike meta-data type, userType is checked first and regardless of typeGuard
+        checkType(value, this.config[0].type);
+      }
+      if (this.config[0].typeGuard) {
+        if (!this.config[0].typeGuard(value)) {
+          throw new Error('Type guard check failed');
+        }
+      }
+      else if (!this.config[0].type) {
+        checkType(value, this.targetType);
+      }
+    }
+    catch (ex) {
+      throw new Error(`Failed to set property "${this.propertyName}": ${ex.message}`);
+    }
+  }
+
+}

--- a/src/internals/TwoWayBinding.ts
+++ b/src/internals/TwoWayBinding.ts
@@ -1,6 +1,7 @@
+import {CustomPropertyDescriptor} from './CustomPropertyDescriptor';
 import {getJsxInfo} from './ExtendedJSX';
 import {subscribe} from './subscribe';
-import {checkPropertyExists, getChild, isUnchecked, TargetPath, WidgetInterface} from './utils-databinding';
+import {checkPropertyExists, getChild, TargetPath, WidgetInterface} from './utils-databinding';
 import {injector} from '../api/Injector';
 import {BindSuperConfig} from '../decorators/bind';
 
@@ -128,7 +129,7 @@ export class TwoWayBinding {
 
   private checkPropertySafety(target: WidgetInterface, property: string, dir: 'Left' | 'Right') {
     checkPropertyExists(target, property);
-    if (isUnchecked(target, property)) {
+    if (CustomPropertyDescriptor.isUnchecked(target, property)) {
       if (isInStrictMode(target)) {
         throw new Error(`${dir} hand property "${property}" requires an explicit type check.`);
       }

--- a/src/internals/applyJsxBindings.ts
+++ b/src/internals/applyJsxBindings.ts
@@ -1,7 +1,8 @@
 import 'reflect-metadata';
 import {Widget, WidgetResizeEvent} from 'tabris';
+import {CustomPropertyDescriptor} from './CustomPropertyDescriptor';
 import {Severity} from './ExtendedJSX';
-import {checkPathSyntax, checkPropertyExists, isUnchecked, WidgetInterface} from './utils-databinding';
+import {checkPathSyntax, checkPropertyExists, WidgetInterface} from './utils-databinding';
 import {Binding} from '../api/to';
 
 const placeholder = /\$\{[^}]+\}/g;
@@ -63,7 +64,7 @@ function createOneWayBindingDesc(
   }
   const path = pathString.split('.');
   checkPropertyExists(target, targetProperty);
-  if (isUnchecked(target, targetProperty)) {
+  if (CustomPropertyDescriptor.isUnchecked(target, targetProperty)) {
     if (unsafe === 'error') {
       throw new Error(`Can not bind to property "${targetProperty}" without explicit type check.`);
     }

--- a/src/internals/utils-databinding.ts
+++ b/src/internals/utils-databinding.ts
@@ -1,8 +1,6 @@
-import {Composite, Listeners, NativeObject, Selector, Widget, WidgetCollection} from 'tabris';
+import {Composite, Listeners, Selector, Widget, WidgetCollection} from 'tabris';
 import {BaseConstructor, Constructor} from './utils';
 
-const uncheckedProperty: unique symbol = Symbol();
-const changeEventsSupport: unique symbol = Symbol();
 const postAppendHandlersKey = Symbol();
 const wasAppendedKey = Symbol();
 const propertyStoreKey = Symbol();
@@ -10,14 +8,10 @@ const componentKey = Symbol();
 
 export const originalAppendKey = Symbol();
 
-export type EventTarget = {
-  [changeEventsSupport]: {[prop: string]: true|undefined}
-};
 export type WidgetInterface = {
   [prop: string]: any,
   [originalAppendKey]: typeof Composite.prototype.append,
-  [wasAppendedKey]: boolean,
-  [uncheckedProperty]: any
+  [wasAppendedKey]: boolean
 } & Widget & WidgetProtected & EventTarget;
 export type TypeGuard<T = any> = (v: T) => boolean;
 export type UserType<T> = Constructor<T>;
@@ -65,40 +59,6 @@ export function checkPropertyExists(targetWidget: any, targetProperty: string, t
     current = Object.getPrototypeOf(current);
   }
   throw new Error(`${targetName} does not have a property "${targetProperty}".`);
-}
-
-export function markAsUnchecked(widget: WidgetInterface, targetProperty: string) {
-  if (!widget[uncheckedProperty]) {
-    widget[uncheckedProperty] = {};
-  }
-  widget[uncheckedProperty][targetProperty] = true;
-}
-
-export function isUnchecked(widget: WidgetInterface, targetProperty: string) {
-  return widget[uncheckedProperty] && widget[uncheckedProperty][targetProperty];
-}
-
-export function markSupportsChangeEvents(target: Partial<EventTarget>, targetProperty: string) {
-  if (!target[changeEventsSupport]) {
-    target[changeEventsSupport] = {};
-  }
-  (target as EventTarget)[changeEventsSupport][targetProperty] = true;
-}
-
-export function supportsChangeEvents(target: Partial<EventTarget>, targetProperty: string): boolean {
-  if (target instanceof NativeObject) {
-    return true; // anyone could fire change events
-  }
-  const changeEvent = targetProperty + 'Changed';
-  const listenerProperty = 'on' + changeEvent.charAt(0).toUpperCase() + changeEvent.slice(1);
-  const listeners: any = target[listenerProperty];
-  if (listeners && listeners.original instanceof Listeners) {
-    if (listeners.original.target !== target || listeners.original.type !== changeEvent) {
-      throw new Error(listenerProperty + ' has wrong target or event type');
-    }
-    return true;
-  }
-  return !!(target[changeEventsSupport] && (target as EventTarget)[changeEventsSupport][targetProperty]);
 }
 
 export function trigger(target: Partial<EventTarget>, type: string, eventData: any) {


### PR DESCRIPTION
Extract CustomPropertyDescriptor.ts from property.ts. For each
@property call (so not per target instance) a new instance of this
class will be created and used to define the property via
Object.defineProperty. It will also be attached as property meta data
so the object can be queried later. This also opens up the possibility
of changing the configuration of the property after its initial
definition, but this is not yet implemented.

supportsChangeEvents function moved from util-databinding to subscribe,
since it's the only user and util-databinding should not gain a
dependency to CustomPropertyDescriptor.