### PR TITLE
Make default value of "default" option of "@prop" type-specific

### DIFF
--- a/doc/databinding/@prop.md
+++ b/doc/databinding/@prop.md
@@ -2,7 +2,16 @@
 ---
 # @prop
 
-An alias for [`@property`](./@property.md), except that it has "smarter" default options and a different shorthand parameter. It's generally recommended over `@property` for custom component development, but its default behavior may be unexpected for newcomers.
+An alias for [`@property`](./@property.md), except that it has "smarter" default options and a different shorthand parameter. It's generally recommended over `@property` for custom component development, but its default behavior may be unexpected for newcomers:
+
+* The initial value is not `undefined` but depends on the type (see next section).
+* All values will be automatically converted to the expected type (if possible).
+* The property can not contain a plain object, but a plain object may be set if it can be converted to the type of the property.
+* If set to `null` or `undefined` the property is reset to its initial value. If the initial value is also `null` (which is the default for non-primitives) an exception is thrown.
+* If the property contains an array and is set to another array that is shallow-equal (has the same length and entries), the property will keep the current value.
+* If used in a JavaScript file (or if the type can not be inferred at runtime in a TypeScript file), the type of the property must be given via `@prop(Class)` or `@prop({type: Class})`, where `Class` may also be `Number`, `String` or `Boolean` to represent primitives. Without type information a warning will be printed the property and all type-specific features (conversion, initial value, type checks) will be disabled.
+
+For details follow the links in the table below.
 
 ## @prop (no parameter)
 
@@ -10,13 +19,14 @@ The following table shows how `@prop` differs in its default configuration from 
 
 Option      | @property  | @prop
 ------------|------------|--------
-`type`      | not set    | not set
-`typeGuard` | not set    | not set
-`default`   | not set    | not set
-`nullable`  | true       | false
-`equals`    | `'strict'` | `'auto'`
-`convert`   | `'off'`    | `'auto'`
+[`type`](./@property.md#configtype)      | not set    | not set
+[`typeGuard`](./@property.md#configtypeguard) | not set    | not set
+[`default`](./@property.md#configdefault)   | not set    | depends on type*
+[`nullable`](./@property.md#confignullable)  | true       | false
+[`equals`](./@property.md#configequals)    | `'strict'` | `'auto'`
+[`convert`](./@property.md#configconvert)   | `'off'`    | `'auto'`
 
+* It's `''` (empty string) for strings, `0` for numbers, `false` for booleans and `null` for all other types.
 
 ## @prop(type)
 

--- a/doc/databinding/@property.md
+++ b/doc/databinding/@property.md
@@ -187,7 +187,7 @@ If set to `'auto'` the property will attempt to convert any new value to the exp
 
 If set to a function, it will be called with the incoming value and must return a value of the expected type. If the value is already of the expected type the function will *not* be called, so it can for example not be used to convert a string to another string. The function may throw an exception if the incoming value can not be converted. The exception will be propagated to the code that is setting the property. If a [type guard](#configtypeguard) is present it will be called *after* the converter with the result of the conversion.
 
-The converter function will never be called with `null` or `undefined` *unless* the target type is a primitive, [nullable](#confignullable) is `false` and [default](#configdefault) is not set.
+The converter function will never be called with `null` or `undefined`.
 
 #### Usage with TypeScript
 
@@ -216,18 +216,16 @@ Below is a list of strategies for each target type.
 
 * `string`:
   * Primitives will be "stringified", e.g. `1` becomes `'1'`
-  * `null` and `undefined` become an empty string
   * Arrays will be joined
   * Objects will be converted by calling `toLocaleString()` or `toString()`, whichever is provided
 * `number`
   * A string will be parsed as a number if it contains a valid JavaScript number expression, including signed, floating point and hex numbers. It also includes `Infinity` and `NaN`
   * Empty strings become `0`
   * `true` becomes `1` and `false` becomes `0`
-  * `null` and `undefined` become `0`
   * `Date` will become a unix timestamp
 * `boolean`
   * String `'true'` becomes `true` and string `'false'` becomes `false`.
-  * `null`, `undefined`  and empty strings become `false`.
+  * Empty strings become `false`.
   * Any number greater than 0 becomes `true`, all other `false`
 * `Array`
   * Strings will be separated by comma in to a string array

--- a/src/decorators/prop.ts
+++ b/src/decorators/prop.ts
@@ -1,6 +1,6 @@
-import {CustomPropertyDecorator, PropertyDecoratorConfig} from '..';
 import {CompareMode} from '../api/equals';
-import {CustomPropertyDescriptor} from '../internals/CustomPropertyDescriptor';
+import {CustomPropertyDecorator, PropertyDecoratorConfig} from '../decorators/property';
+import {autoDefault, CustomPropertyDescriptor} from '../internals/CustomPropertyDescriptor';
 import {applyDecorator} from '../internals/utils';
 import {TypeGuard, UserType} from '../internals/utils-databinding';
 
@@ -105,10 +105,10 @@ function getNullable(arg: unknown): boolean {
 
 function getDefaultValue(arg: unknown): any {
   if (arg instanceof Function) {
-    return undefined;
+    return autoDefault;
   }
   if (arg instanceof Object && arg.constructor === Object && 'default' in arg) {
     return (arg as any).default;
   }
-  return undefined;
+  return autoDefault;
 }

--- a/test/prop.spec.ts
+++ b/test/prop.spec.ts
@@ -20,7 +20,10 @@ describe('prop', () => {
       @prop foo: string;
 
       @event onBarChanged: ChangeListeners<this, 'bar'>;
-      @prop({}) bar: string;
+      @(prop as any)() bar: number;
+
+      @event onBazChanged: ChangeListeners<this, 'baz'>;
+      @prop({}) baz: boolean;
 
       @event onColorChanged: ChangeListeners<this, 'color'>;
       @prop(Color)
@@ -46,11 +49,13 @@ describe('prop', () => {
 
     it('uses "auto" convert', () => {
       (example as any).foo = 1;
-      (example as any).bar = 2;
+      (example as any).bar = '2';
+      (example as any).baz = 'true';
       example.color = 'red';
 
       expect(example.foo).to.equal('1');
-      expect(example.bar).to.equal('2');
+      expect(example.bar).to.equal(2);
+      expect(example.baz).to.be.true;
       expect(example.color).to.be.instanceOf(Color);
     });
 
@@ -63,7 +68,24 @@ describe('prop', () => {
       expect(listener).not.to.have.been.called;
     });
 
+    it('sets "default" depending on property type', () => {
+      expect(example.foo).to.equal('');
+      expect(example.bar).to.equal(0);
+      expect(example.baz).to.equal(false);
+      expect(example.color).to.be.null;
+    });
+
     it('is not nullable', () => {
+      example.foo = 'foo';
+      example.foo = null;
+      example.bar = 1;
+      example.bar = null;
+      example.baz = true;
+      example.baz = null;
+
+      expect(example.foo).to.equal('');
+      expect(example.bar).to.equal(0);
+      expect(example.baz).to.equal(false);
       expect(() => example.color = null).to.throw(Error, 'not nullable');
     });
 

--- a/test/property.spec.ts
+++ b/test/property.spec.ts
@@ -290,10 +290,10 @@ describe('property', () => {
       expect(example.auto).to.be.null;
     });
 
-    it('"auto" converts null for non-nullable primitive type', () => {
+    it('"auto" does not convert null for non-nullable primitive type', () => {
       example.nonNullable = 'foo';
-      example.nonNullable = null;
-      expect(example.nonNullable).to.equal('');
+
+      expect(() => example.nonNullable = null).to.throw(Error);
     });
 
     it('"auto" does not convert null for object type', () => {


### PR DESCRIPTION
As a side effect a given converter will now never be called with
null/undefined.