### PR TITLE
Add option to @component to wrap constructor as a factory

### DIFF
--- a/examples/connect-js/src/ExampleComponent.js
+++ b/examples/connect-js/src/ExampleComponent.js
@@ -12,7 +12,7 @@ const dispatchToProps = dispatch => ({
   onToggle: ev => dispatch({type: 'TOGGLE_STRING', checked: ev.checked})
 });
 
-const ExampleComponent = component(class ExampleComponent extends Composite {
+const ExampleComponent = class ExampleComponent extends Composite {
 
   /**
    * @param {tabris.Properties<ExampleComponent>=} properties
@@ -45,6 +45,8 @@ const ExampleComponent = component(class ExampleComponent extends Composite {
     return this._msg.text;
   }
 
-});
+};
 
-exports.ExampleComponent = connect(stateToProps, dispatchToProps)(ExampleComponent);
+exports.ExampleComponent = connect(stateToProps, dispatchToProps)(
+  component({factory: true})(ExampleComponent)
+);

--- a/examples/connect-js/src/FunctionalComponent.js
+++ b/examples/connect-js/src/FunctionalComponent.js
@@ -3,11 +3,11 @@ const {connect} = require('tabris-decorators');
 /* globals StateToProps, DispatchToProps */
 
 exports.FunctionalComponent = connect(
-  /** @type {StateToProps<Button>} */
+  /** @type {StateToProps<tabris.Button>} */
   state => ({text: 'Random number: ' + state.num}),
-  /** @type {DispatchToProps<Button>} */
+  /** @type {DispatchToProps<tabris.Button>} */
   dispatch => ({onSelect: () => dispatch({type: 'SET_RANDOM_NUMBER'})})
 )(
-  /** @param {tabris.Properties<Button>} properties */
-  properties => new Button({font: '12px serif', textColor: 'black'}).set(properties)
+  /** @param {tabris.Attributes<tabris.Button>} attr */
+  attr => Button({font: '12px serif', textColor: 'black', ...attr})
 );

--- a/examples/connect-js/src/app.js
+++ b/examples/connect-js/src/app.js
@@ -24,8 +24,12 @@ const reducers = {
 register(StateProvider, createStore(combineReducers(reducers)));
 
 contentView.append(
-  new Stack({padding: 12, spacing: 12}).append(
-    new ExampleComponent({background: Color.silver}),
-    FunctionalComponent({background: Color.yellow})
-  )
+  Stack({
+    padding: 12,
+    spacing: 12,
+    children: [
+      ExampleComponent({background: Color.silver}),
+      FunctionalComponent({background: Color.yellow})
+    ]
+  })
 );

--- a/src/decorators/component.ts
+++ b/src/decorators/component.ts
@@ -1,8 +1,15 @@
 import 'reflect-metadata';
-import {Composite, Widget, WidgetCollection} from 'tabris';
+import {asFactory, CallableConstructor, Composite, Widget, WidgetCollection} from 'tabris';
 import {isAppended, markAsAppended, markAsComponent, originalAppendKey, postAppendHandlers, WidgetInterface} from '../internals//utils-databinding';
 import {processOneWayBindings} from '../internals/processOneWayBindings';
 import {applyDecorator, BaseConstructor, Constructor} from '../internals/utils';
+
+type ComponentOptions = {};
+type ComponentNonFactoryOptions = ComponentOptions & {factory?: false};
+type ComponentFactoryOptions = ComponentOptions & {factory: true};
+type ComponentOptionsUnion = ComponentOptions & {factory?: boolean};
+type ComponentDecorator = <T extends Constructor<Composite>>(arg: T) => T;
+type ComponentAsFactory = <T extends Constructor<Composite>>(arg: T) => CallableConstructor<T>;
 
 /**
  * A decorator for classes extending `Composite` (directly or indirectly),
@@ -26,12 +33,19 @@ import {applyDecorator, BaseConstructor, Constructor} from '../internals/utils';
  *    using either `@getById` or the protected `_children`, `_find` and `_apply` methods.*
  * * *For creating two-way bindings use `@bind` and `@bindAll`.*
  */
-export function component<T extends Constructor<Composite>>(arg: T): T {
+export function component<T extends Constructor<Composite>>(arg: T): CallableConstructor<T>;
+export function component(options: ComponentNonFactoryOptions): ComponentDecorator;
+export function component(options: ComponentFactoryOptions): ComponentAsFactory;
+export function component<T>(arg: T): T | ComponentDecorator | ComponentAsFactory {
   return applyDecorator('component', [arg], (type: Constructor<Composite>) => {
+    const options: ComponentOptionsUnion = arg instanceof Function ? {} : arg;
     markAsComponent(type);
     isolate(type);
     addOneWayBindingsProcessor(type);
     patchAppend(type);
+    if (options.factory) {
+      return asFactory(type);
+    }
     return type;
   });
 }

--- a/test/component-factory.spec.ts
+++ b/test/component-factory.spec.ts
@@ -1,0 +1,64 @@
+import 'mocha';
+import 'sinon';
+import {Button, Composite, Properties, tabris, Widget} from 'tabris';
+import ClientMock from 'tabris/ClientMock';
+import {expect, restoreSandbox, spy} from './test';
+import {component, getById, injector} from '../src';
+
+class OriginalCustomComponent extends Composite {
+
+  constructor(properties: Properties<Composite>) {
+    super(properties);
+    this.append(Composite());
+  }
+
+}
+
+const CustomComponent = component({factory: true})(OriginalCustomComponent);
+type CustomComponent = OriginalCustomComponent;
+
+describe('component({factory: true})', () => {
+
+  let widget: CustomComponent;
+  let parent: Composite;
+
+  beforeEach(() => {
+    tabris._init(new ClientMock());
+    parent = new Composite();
+    widget = new CustomComponent({}, true);
+    parent.append(widget);
+  });
+
+  afterEach(() => {
+    restoreSandbox();
+  });
+
+  beforeEach(function() {
+    spy(injector.jsxProcessor, 'createCustomComponent');
+  });
+
+  it('is factory for given type', function() {
+    expect(CustomComponent()).to.be.instanceOf(CustomComponent);
+    expect(CustomComponent()).to.be.instanceOf(OriginalCustomComponent);
+  });
+
+  it('isolates', function() {
+    expect(CustomComponent().children().length).to.equal(0);
+  });
+
+  it('calls createElement', function() {
+    const attr = {top: 23};
+
+    CustomComponent(attr);
+
+    expect(injector.jsxProcessor.createCustomComponent).to.have.been.calledOnce;
+    expect(injector.jsxProcessor.createCustomComponent).to.have.been.calledWith(OriginalCustomComponent, attr);
+  });
+
+  it('does not double-wrap', function() {
+    const Component2 = component(CustomComponent);
+    expect(Component2[tabris.symbols.originalComponent]).to.equal(OriginalCustomComponent);
+    expect(Component2[tabris.symbols.originalComponent]).not.to.equal(CustomComponent);
+  });
+
+});

--- a/test/connect-js.spec.js
+++ b/test/connect-js.spec.js
@@ -81,11 +81,6 @@ describe('connect', () => {
     );
   });
 
-  it('implies @component', () => {
-    instance.append(new TextView());
-    expect(instance.children().length).to.equal(0);
-  });
-
   it('maps state on state change', () => {
     currentState.stateString = 'baz';
     subscribers.forEach(cb => cb());


### PR DESCRIPTION
Based on the new "asFactory" function of tabris 3.6. Unfortunately this
requires a separate function signature and can only be used when
component is calles as a function. This is because a class decorator can
not modify the interface of the constructor.

Use the new factory API in the connect-js example project.

Removed one (legitimately) broken test.