### PR TITLE
📦 Make compatible with nightly Tabris.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "webpack-merge": "^4.2.1"
       },
       "peerDependencies": {
-        "tabris": "^3.9.0"
+        "tabris": "^3.9.0-dev"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "start:windows": ".\\launch.cmd"
   },
   "peerDependencies": {
-    "tabris": "^3.9.0"
+    "tabris": "^3.9.0-dev"
   },
   "devDependencies": {
     "@types/chai": "^4.2.0",


### PR DESCRIPTION
The selector `^3.9.0` does not match the nightly Tabris.js version pattern `3.9.0-dev...`. With latest `npm@9`, this resulted in a build failure when using nightly Tabris.js together with latest Tabris Decorators.

Update the selector of the Tabris.js peer dependency to `^3.9.0-dev`. It preferably matches the version `3.9.0` but it also matches the nightly version pattern `3.9.0-dev`, enabling `tabris-decorators` to be used with nightly Tabris.js versions.